### PR TITLE
turn-off-tutorial-default - Adjusted code so that user tutorials are turned off by default

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -94,7 +94,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.241.006"
+VERSION = "0.241.007"
 
 SECRET_KEY = os.getenv('SECRET_KEY', 'dev-secret-key-change-in-production')
 

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -1055,7 +1055,7 @@ def get_user_settings(user_id):
         if 'personal_model_endpoints' not in doc['settings']:
             doc['settings']['personal_model_endpoints'] = []
         if 'showTutorialButtons' not in doc['settings']:
-            doc['settings']['showTutorialButtons'] = True
+            doc['settings']['showTutorialButtons'] = False
             updated = True
         
         # Try to update email/display_name if missing and available in session
@@ -1098,7 +1098,7 @@ def get_user_settings(user_id):
         display_name = user.get("name")
         doc = {"id": user_id, "settings": {}}
         doc["settings"]["personal_model_endpoints"] = []
-        doc["settings"]["showTutorialButtons"] = True
+        doc["settings"]["showTutorialButtons"] = False
         if email:
             doc["email"] = email
         if display_name:

--- a/application/single_app/templates/chats.html
+++ b/application/single_app/templates/chats.html
@@ -1057,7 +1057,7 @@
     </div>
 </div>
 
-{% if user_settings.get('settings', {}).get('showTutorialButtons', True) %}
+{% if user_settings.get('settings', {}).get('showTutorialButtons', False) %}
 <!-- Chat Tutorial Launch Button -->
 <div id="chat-tutorial-launch" class="position-fixed top-0 end-0 p-3">
     <button

--- a/application/single_app/templates/profile.html
+++ b/application/single_app/templates/profile.html
@@ -350,7 +350,7 @@
                 <div>
                     <h5 class="mb-2"><i class="bi bi-sliders me-2"></i>Tutorial Preferences</h5>
                     <p class="text-muted mb-2">Control whether the floating guided tutorial buttons appear on Chat and Personal Workspace for your account.</p>
-                    <p class="small text-muted mb-0">These launchers are shown by default. You can hide them now and turn them back on later from this page.</p>
+                    <p class="small text-muted mb-0">These launchers are hidden by default. You can turn them on here at any time.</p>
                 </div>
             </div>
             {% if app_settings.enable_support_menu and app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items %}
@@ -367,12 +367,12 @@
                         class="form-check-input"
                         type="checkbox"
                         id="show-tutorial-buttons-toggle"
-                        {% if user_settings.get('settings', {}).get('showTutorialButtons', True) %}checked{% endif %}
+                        {% if user_settings.get('settings', {}).get('showTutorialButtons', False) %}checked{% endif %}
                     />
                     <label class="form-check-label fw-semibold" for="show-tutorial-buttons-toggle">
                         Show tutorial buttons on Chat and Personal Workspace
                     </label>
-                    <small class="d-block text-muted mt-1">Turn this off if you already know the interface and want to remove the floating walkthrough launchers.</small>
+                    <small class="d-block text-muted mt-1">Turn this on if you want floating walkthrough launchers on Chat and Personal Workspace.</small>
                 </div>
             </div>
             <div class="col-lg-4 text-lg-end">
@@ -1532,8 +1532,8 @@ function loadTutorialPreferences() {
     fetch('/api/user/settings')
         .then(response => response.json())
         .then(data => {
-            toggle.checked = data.settings?.showTutorialButtons !== false;
-            updateTutorialPreferenceStatus('Tutorial launchers are shown by default until you change this setting.');
+            toggle.checked = data.settings?.showTutorialButtons === true;
+            updateTutorialPreferenceStatus('Tutorial launchers are hidden by default until you enable this setting.');
         })
         .catch(error => {
             console.error('Error loading tutorial preferences:', error);

--- a/application/single_app/templates/workspace.html
+++ b/application/single_app/templates/workspace.html
@@ -1504,7 +1504,7 @@
   </div>
 </div>
 
-{% if user_settings.get('settings', {}).get('showTutorialButtons', True) %}
+{% if user_settings.get('settings', {}).get('showTutorialButtons', False) %}
 <div id="workspace-tutorial-launch" class="position-fixed top-0 end-0 p-3 is-ready">
   <button
       id="workspace-tutorial-btn"

--- a/docs/explanation/features/v0.241.001/USER_TUTORIAL_VISIBILITY_PREFERENCE.md
+++ b/docs/explanation/features/v0.241.001/USER_TUTORIAL_VISIBILITY_PREFERENCE.md
@@ -24,7 +24,7 @@ The preference is stored as a per-user setting named `showTutorialButtons` insid
 
 ### Configuration and Data Flow
 
-- `functions_settings.get_user_settings()` now ensures `showTutorialButtons` exists and defaults to `True`.
+- `functions_settings.get_user_settings()` now ensures `showTutorialButtons` exists and defaults to `False`.
 - `route_backend_users.py` allows `showTutorialButtons` through the shared `/api/user/settings` update endpoint.
 - `profile.html` exposes a dedicated Tutorial Preferences card with a toggle and save action.
 - `chats.html` and `workspace.html` only render tutorial launchers when the current user setting is enabled.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -1,8 +1,18 @@
 <!-- BEGIN release_notes.md BLOCK -->
 
-This page tracks notable Simple Chat releases and organizes the detailed change log by version. The timeline below provides a quick visual overview of the current release progression through v0.240.002, and the per-version entries continue immediately after it.
+This page tracks notable Simple Chat releases and organizes the detailed change log by version. The timeline below provides a quick visual overview of the current release progression through v0.241.007, and the per-version entries continue immediately after it.
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
+
+### **(v0.241.007)**
+
+#### Bug Fixes
+
+*   **Tutorial Visibility Default Preference Persistence**
+    *   Fixed the Profile tutorial preference loader so a missing `showTutorialButtons` value now resolves to hidden (`false`) instead of being interpreted as enabled.
+    *   This prevents the UI from unintentionally treating an unset Cosmos setting as `true` and writing the toggle back as enabled during later saves.
+    *   Updated profile helper text to match the hidden-by-default behavior and refreshed functional coverage markers for the revised default logic.
+    *   (Ref: `profile.html`, `test_user_tutorial_visibility_preference.py`, `application/single_app/config.py`)
 
 ### **(v0.241.006)**
 

--- a/functional_tests/test_user_tutorial_visibility_preference.py
+++ b/functional_tests/test_user_tutorial_visibility_preference.py
@@ -2,10 +2,10 @@
 # test_user_tutorial_visibility_preference.py
 """
 Functional test for user tutorial visibility preference.
-Version: 0.241.003
-Implemented in: 0.240.068; 0.241.002; 0.241.003
+Version: 0.241.007
+Implemented in: 0.240.068; 0.241.002; 0.241.003; 0.241.007
 
-This test ensures that guided tutorial launchers remain visible by default,
+This test ensures that guided tutorial launchers are hidden by default,
 users can manage the preference from the profile page, and the Latest Features
 experience points users back to profile settings when they want to hide or
 restore tutorial buttons.
@@ -45,13 +45,13 @@ def test_user_tutorial_visibility_preference() -> bool:
     latest_features_content = read_text(LATEST_FEATURES_TEMPLATE_FILE)
 
     required_config_markers = [
-        'VERSION = "0.241.003"',
+        'VERSION = "0.241.007"',
     ]
     missing_config = [marker for marker in required_config_markers if marker not in config_content]
     assert not missing_config, f"Missing config markers: {missing_config}"
 
     required_settings_markers = [
-        "doc['settings']['showTutorialButtons'] = True",
+        "doc['settings']['showTutorialButtons'] = False",
         'if \'showTutorialButtons\' not in doc[\'settings\']:',
     ]
     missing_settings = [marker for marker in required_settings_markers if marker not in settings_content]
@@ -70,14 +70,15 @@ def test_user_tutorial_visibility_preference() -> bool:
         'onclick="saveTutorialPreferences()"',
         "function loadTutorialPreferences()",
         "function saveTutorialPreferences()",
+        "toggle.checked = data.settings?.showTutorialButtons === true;",
         "showTutorialButtons: toggle.checked",
-        "These launchers are shown by default.",
+        "These launchers are hidden by default.",
     ]
     missing_profile = [marker for marker in required_profile_markers if marker not in profile_content]
     assert not missing_profile, f"Missing profile preference markers: {missing_profile}"
 
     required_template_guards = [
-        "{% if user_settings.get('settings', {}).get('showTutorialButtons', True) %}",
+        "{% if user_settings.get('settings', {}).get('showTutorialButtons', False) %}",
         'id="chat-tutorial-launch"',
         'id="workspace-tutorial-launch"',
     ]


### PR DESCRIPTION
This pull request changes the default behavior for the tutorial launcher buttons so that they are now hidden by default for all users, instead of being shown by default. The update ensures that both the backend logic and frontend UI consistently treat the absence of a user preference as "hidden," and updates documentation and tests to match this new default.

**User Tutorial Button Visibility Default Change**

* The default value for the `showTutorialButtons` user setting is now `False` throughout the backend (`functions_settings.py`), meaning new and unset users will not see tutorial launchers unless they explicitly enable them. [[1]](diffhunk://#diff-de236109ddd9bdab5101c7e21121a4f548f704da2207cf0150f3fd498774f976L1058-R1058) [[2]](diffhunk://#diff-de236109ddd9bdab5101c7e21121a4f548f704da2207cf0150f3fd498774f976L1101-R1101)
* All template guards in `chats.html` and `workspace.html` now check for `showTutorialButtons` being `True`, but default to hidden if the setting is missing. [[1]](diffhunk://#diff-b13d2a63decdd22e12d202c8f72ee3e267a7ce1bbaf179bbcd0a75035f6d07e5L1060-R1060) [[2]](diffhunk://#diff-d410d84531b6d4793a411fb1af49b676b2a1619f418d30fd46552bd45ed9f52eL1507-R1507)
* The tutorial preference toggle on the profile page now reflects the new default, and the helper text is updated to communicate that launchers are hidden by default. [[1]](diffhunk://#diff-34a17a61ecbe46c713bd3fca2210a70f711445d32953eb4b646603a14d92eb54L353-R353) [[2]](diffhunk://#diff-34a17a61ecbe46c713bd3fca2210a70f711445d32953eb4b646603a14d92eb54L370-R375) [[3]](diffhunk://#diff-34a17a61ecbe46c713bd3fca2210a70f711445d32953eb4b646603a14d92eb54L1535-R1536)

**Documentation and Test Updates**

* Documentation in `USER_TUTORIAL_VISIBILITY_PREFERENCE.md` and release notes is updated to describe the new hidden-by-default behavior and to clarify the data flow. [[1]](diffhunk://#diff-c463f0045c841bc5e8a6b52fe3fc1515eee7cb5913c5ceba793efbb406513bbbL27-R27) [[2]](diffhunk://#diff-f5063be9f51b26101d79e241073883a1556ea50c0d7e1726af8dfc832d44d516L3-R16)
* Functional tests are updated to expect the new default, including config markers and template guards. [[1]](diffhunk://#diff-f78c6a1b40eb37ed3b49ff86419bee5091105772270a3f98ed0e3fc18c676ba4L5-R8) [[2]](diffhunk://#diff-f78c6a1b40eb37ed3b49ff86419bee5091105772270a3f98ed0e3fc18c676ba4L48-R54) [[3]](diffhunk://#diff-f78c6a1b40eb37ed3b49ff86419bee5091105772270a3f98ed0e3fc18c676ba4R73-R81)

**Version Bump**

* The application version is incremented to `0.241.007` to reflect these changes.